### PR TITLE
Fix `timeout` validation in `helm` schema

### DIFF
--- a/__tests__/validator.unit.spec.js
+++ b/__tests__/validator.unit.spec.js
@@ -4061,6 +4061,11 @@ describe('Validate Codefresh YAML', () => {
                     steps: {
                         pending: {
                             type: 'pending-approval',
+                            timeout: {
+                                timeUnit: 'minutes',
+                                duration: 10,
+                                finalState: 'denied',
+                            }
                         }
                     }
                 });
@@ -5020,6 +5025,7 @@ describe('Validate Codefresh YAML', () => {
                                                     service: 'kubernetes',
                                                     cluster: '${{test-cluster}}',
                                                     namespace: 'default',
+                                                    timeout: '150',
                                                     arguments: {
                                                         image: '${{build}}',
                                                         registry: 'cfcr',

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "bin": {
     "cyv": "./index.js"
   },
-  "version": "0.33.0",
+  "version": "0.33.1",
   "main": "./validator.js",
   "scripts": {
     "test": "jest --coverage --runInBand",

--- a/schema/1.0/steps/helm.js
+++ b/schema/1.0/steps/helm.js
@@ -16,6 +16,7 @@ class Helm extends BaseSchema {
         const HelmProperties = {
             'type': Joi.string().valid(Helm.getType()),
             'working_directory': Joi.string(),
+            'timeout': Joi.string(),
         };
         return this._createSchema(HelmProperties)
             .unknown();


### PR DESCRIPTION
This adds `timeout` validation for Helm step.

Helm step has its own timeout that is not compatible with recently introduced root-level `timeout` thus requires its own validation logic.