### PR TITLE
fix: resolve arguments conflicts

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "bin": {
     "cyv": "./index.js"
   },
-  "version": "0.33.1",
+  "version": "0.33.2",
   "main": "./validator.js",
   "scripts": {
     "test": "jest --coverage --runInBand",

--- a/schema/1.0/steps/helm.js
+++ b/schema/1.0/steps/helm.js
@@ -16,7 +16,6 @@ class Helm extends BaseSchema {
         const HelmProperties = {
             'type': Joi.string().valid(Helm.getType()),
             'working_directory': Joi.string(),
-            'timeout': Joi.string(),
         };
         return this._createSchema(HelmProperties)
             .unknown();


### PR DESCRIPTION
In order to avoid conflicts between arguments and root-level step properties, copy arguments to the step only if step is known to the planner. Do not override root properties if they are already defined.