### PR TITLE
fix: copy arguments to root for typed steps

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "bin": {
     "cyv": "./index.js"
   },
-  "version": "0.33.2",
+  "version": "0.33.3",
   "main": "./validator.js",
   "scripts": {
     "test": "jest --coverage --runInBand",


### PR DESCRIPTION
Some users rely on the earlier behavior when well-known arguments of the typed steps (for example, `working_directory`) are copied to the root. This PR reverts previous changes in order to bring earlier behavior back.

Fixes #CR-21167