### PR TITLE
feat: add `strict_fail_fast` field

### DIFF
--- a/__tests__/validator.unit.spec.js
+++ b/__tests__/validator.unit.spec.js
@@ -443,6 +443,42 @@ describe('Validate Codefresh YAML', () => {
                 }, '"on_something" is not allowed', done);
             });
         });
+
+        describe('strict_fail_fast', () => {
+            it('should pass if "strict_fail_fast" was not defined', () => {
+                validate({
+                    version: '1.0',
+                    steps: { mock: { image: 'mock-image' } },
+                });
+            });
+
+            it.each([
+                true,
+                false,
+            ])('should pass if "strict_fail_fast" is valid boolean: %s', (strictFailFast) => {
+                validate({
+                    version: '1.0',
+                    steps: { mock: { image: 'mock-image' } },
+                    strict_fail_fast: strictFailFast,
+                });
+            });
+
+            it.each([
+                0,
+                42,
+                '',
+                'mock',
+                null,
+                {},
+                [],
+            ])(`should not pass if "strict_fail_fast" is invalid data type: %s`, (strictFailFast, done) => {
+                validateForError({
+                    version: '1.0',
+                    steps: { mock: { image: 'mock-image' } },
+                    strict_fail_fast: strictFailFast,
+                }, `"strict_fail_fast" must be a boolean`, done);
+            });
+        });
     });
 
     describe('Steps', () => {
@@ -1173,6 +1209,40 @@ describe('Validate Codefresh YAML', () => {
                     //     }, `fails to match the "\\<duration\\>\\<units\\> where duration is int\\|float and units are s\\|m\\|h" pattern`, done);
                     // });
                     // END: Uncomment once timeout is required. ⬆️
+                });
+            });
+
+            describe('strict_fail_fast', () => {
+                it('should pass if "strict_fail_fast" was not defined', () => {
+                    validate({
+                        version: '1.0',
+                        steps: { mock: { image: 'mock-image' } },
+                    });
+                });
+
+                it.each([
+                    true,
+                    false,
+                ])('should pass if "strict_fail_fast" is valid boolean: %s', (strictFailFast) => {
+                    validate({
+                        version: '1.0',
+                        steps: { mock: { image: 'mock-image', strict_fail_fast: strictFailFast } },
+                    });
+                });
+
+                it.each([
+                    0,
+                    42,
+                    '',
+                    'mock',
+                    null,
+                    {},
+                    [],
+                ])(`should not pass if "strict_fail_fast" is invalid data type: %s`, (strictFailFast, done) => {
+                    validateForError({
+                        version: '1.0',
+                        steps: { mock: { image: 'mock-image', strict_fail_fast: strictFailFast } },
+                    }, `"strict_fail_fast" must be a boolean`, done);
                 });
             });
         });

--- a/__tests__/validator.unit.spec.js
+++ b/__tests__/validator.unit.spec.js
@@ -445,17 +445,11 @@ describe('Validate Codefresh YAML', () => {
         });
 
         describe('strict_fail_fast', () => {
-            it('should pass if "strict_fail_fast" was not defined', () => {
-                validate({
-                    version: '1.0',
-                    steps: { mock: { image: 'mock-image' } },
-                });
-            });
-
             it.each([
                 true,
                 false,
-            ])('should pass if "strict_fail_fast" is valid boolean: %s', (strictFailFast) => {
+                undefined,
+            ])('should pass if "strict_fail_fast" is valid data type: %s', (strictFailFast) => {
                 validate({
                     version: '1.0',
                     steps: { mock: { image: 'mock-image' } },
@@ -1213,17 +1207,11 @@ describe('Validate Codefresh YAML', () => {
             });
 
             describe('strict_fail_fast', () => {
-                it('should pass if "strict_fail_fast" was not defined', () => {
-                    validate({
-                        version: '1.0',
-                        steps: { mock: { image: 'mock-image' } },
-                    });
-                });
-
                 it.each([
                     true,
                     false,
-                ])('should pass if "strict_fail_fast" is valid boolean: %s', (strictFailFast) => {
+                    undefined,
+                ])('should pass if "strict_fail_fast" is valid data type: %s', (strictFailFast) => {
                     validate({
                         version: '1.0',
                         steps: { mock: { image: 'mock-image', strict_fail_fast: strictFailFast } },

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "bin": {
     "cyv": "./index.js"
   },
-  "version": "0.33.5",
+  "version": "0.34.0",
   "main": "./validator.js",
   "scripts": {
     "test": "jest --coverage --runInBand",

--- a/schema/1.0/base-schema.js
+++ b/schema/1.0/base-schema.js
@@ -82,6 +82,7 @@ class BaseSchema {
             'description': Joi.string(),
             'title': Joi.string(),
             'fail_fast': Joi.boolean(),
+            'strict_fail_fast': Joi.boolean().strict().optional(),
             'docker_machine': Joi.alternatives().try(
                 [
                     Joi.object({

--- a/schema/1.0/validator.js
+++ b/schema/1.0/validator.js
@@ -357,10 +357,11 @@ class Validator {
             mode: Joi.string().valid('sequential', 'parallel'),
             hooks: BaseSchema._getBaseHooksSchema(),
             fail_fast: [Joi.object(), Joi.string(), Joi.boolean()],
+            strict_fail_fast: Joi.boolean().strict().optional(),
             success_criteria: BaseSchema.getSuccessCriteriaSchema(),
             indicators: Joi.array(),
             services: Joi.object(),
-            build_version: Joi.string().valid('v1', 'v2')
+            build_version: Joi.string().valid('v1', 'v2'),
         });
         const validationResult = Joi.validate(objectModel, rootSchema, { abortEarly: false });
         if (validationResult.error) {
@@ -830,6 +831,7 @@ class Validator {
         const multipleStepsSchema = Joi.object({
             mode: Joi.string().valid('sequential', 'parallel'),
             fail_fast: Joi.boolean(),
+            strict_fail_fast: Joi.boolean().strict().optional(),
             steps: Joi.object().pattern(/^.+$/, Joi.object()),
         });
 
@@ -851,6 +853,7 @@ class Validator {
             hookSchema = Joi.object({
                 mode: Joi.string().valid('sequential', 'parallel'),
                 fail_fast: Joi.boolean(),
+                strict_fail_fast: Joi.boolean().strict().optional(),
                 steps: Joi.object().pattern(/^.+$/, Joi.object()),
             });
         } else {


### PR DESCRIPTION
This adds `strict_fail_fast` optional boolean field, which is allowed to use in the same places where `fail_fast` is allowed.

Relates to #CR-21418