### PR TITLE
fix(suggestion): do not suggest props that equals to not allowed one

### DIFF
--- a/__tests__/validator.unit.spec.js
+++ b/__tests__/validator.unit.spec.js
@@ -2036,7 +2036,7 @@ describe('Validate Codefresh YAML', () => {
                                 'lines': 15
                             },
                             {
-                                'message': '"platform" is not allowed. Did you mean "platform"?',
+                                'message': '"platform" is not allowed',
                                 'type': 'Validation',
                                 'path': 'steps',
                                 'context': {
@@ -2047,13 +2047,9 @@ describe('Validate Codefresh YAML', () => {
                                 'docsLink': 'https://codefresh.io/docs/docs/pipelines/steps/build/',
                                 'actionItems': 'Please make sure you have all the required fields and valid values',
                                 'lines': 29,
-                                'suggestion': {
-                                    'from': 'platform',
-                                    'to': 'platform'
-                                }
                             },
                             {
-                                'message': '"platform" is not allowed. Did you mean "platform"?',
+                                'message': '"platform" is not allowed',
                                 'type': 'Validation',
                                 'path': 'steps',
                                 'context': {
@@ -2064,10 +2060,6 @@ describe('Validate Codefresh YAML', () => {
                                 'docsLink': 'https://codefresh.io/docs/docs/pipelines/steps/build/',
                                 'actionItems': 'Please make sure you have all the required fields and valid values',
                                 'lines': 44,
-                                'suggestion': {
-                                    'from': 'platform',
-                                    'to': 'platform'
-                                }
                             },
                             {
                                 'message': '"platform" must be a string. Current value: 123 ',

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "bin": {
     "cyv": "./index.js"
   },
-  "version": "0.35.0",
+  "version": "0.35.1",
   "main": "./validator.js",
   "scripts": {
     "test": "jest --coverage --runInBand",

--- a/schema/1.0/validations/suggest-argument.js
+++ b/schema/1.0/validations/suggest-argument.js
@@ -39,7 +39,9 @@ class SuggestArgumentValidation {
 
 
     static _getNearestMatchingProperty(stepProperties, wrongKey) {
-        const propertiesStartedFromKey = stepProperties.filter(prop => prop.startsWith(wrongKey));
+        const propertiesStartedFromKey = stepProperties.filter((property) => {
+            return property !== wrongKey && property.startsWith(wrongKey);
+        });
         if (propertiesStartedFromKey.length) {
             return _.first(propertiesStartedFromKey.sort((a, b) => a.length - b.length));
         }
@@ -51,7 +53,10 @@ class SuggestArgumentValidation {
 
 
     static _getPossibleProperties(stepProperties, wrongKey) {
-        return stepProperties.filter(property => Math.abs(property.length - wrongKey.length) < this.lengthThreshold);
+        return stepProperties.filter((property) => {
+            return property !== wrongKey
+                && Math.abs(property.length - wrongKey.length) < this.lengthThreshold;
+        });
     }
 
 


### PR DESCRIPTION
This excludes wrong properties itself from the suggestion list in order to avoid meaningless suggestions a la `"platform" is not allowed. Did you mean "platform"?`

Fixes #CR-22362