### PR TITLE
fix: do not validate step type if it contains variables

### DIFF
--- a/__tests__/validator.unit.spec.js
+++ b/__tests__/validator.unit.spec.js
@@ -1250,6 +1250,18 @@ describe('Validate Codefresh YAML', () => {
                     }, 'message');
                 });
                 it.each([
+                    '${{TYPE}}',
+                    '${{PART}}-of-type',
+                    'type:${{VERSION}}',
+                    'type:part-of-${{VERSION}}',
+                    '${{PART}}-of-type:part-of-${{VERSION}}',
+                ])('should not fail if type contains variables: "%s"', (type) => {
+                    Validator.validate({
+                        version: '1.0',
+                        steps: { mock: { type } },
+                    }, 'message');
+                });
+                it.each([
                     'foo',
                     42,
                     0,

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "bin": {
     "cyv": "./index.js"
   },
-  "version": "0.35.0",
+  "version": "0.35.2",
   "main": "./validator.js",
   "scripts": {
     "test": "jest --coverage --runInBand",

--- a/schema/1.0/constants/variable-regex.js
+++ b/schema/1.0/constants/variable-regex.js
@@ -1,0 +1,7 @@
+'use strict';
+
+const VARIABLE_REGEX = /\$\{{2}.+?\}{2}/;
+
+module.exports = {
+    VARIABLE_REGEX,
+};


### PR DESCRIPTION
We're unable to resolve variables at validation stage so step type should not be validated if contains variable(s).

Fixes #CR-22348